### PR TITLE
Warning added to frozen version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2017 Timur Gilmullin, tim55667757@gmail.com
+Copyright (c) 2017 Open DevOps Community
+Project Lead, main ideas, author of fuzzy measuring scales: Timur Gilmullin, tim55667757@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ FuzzyClassificator
 
 This program uses neural networks to solve classification problems, and uses fuzzy sets and fuzzy logic to interpreting results. FuzzyClassificator provided under the MIT License.
 
+**[WARNING]** The development is frozen here and moved to the Open DevOps community: [https://github.com/devopshq/FuzzyClassificator](https://github.com/devopshq/FuzzyClassificator)
+
+You can see detailed user manual here: 
+[https://devopshq.github.io/FuzzyClassificator/](https://devopshq.github.io/FuzzyClassificator/)
+
+**Please report all new bugs or the required functionality in new tasks in Open DevOps community.**
+
+See article about math in FuzzyClassificator (russian):
+[http://math-n-algo.blogspot.ru/2014/08/FuzzyClassificator.html](http://math-n-algo.blogspot.ru/2014/08/FuzzyClassificator.html)
+
 
 How to use
 --------------


### PR DESCRIPTION
**[WARNING]** The development is frozen here and moved to the Open DevOps community: [https://github.com/devopshq/FuzzyClassificator](https://github.com/devopshq/FuzzyClassificator)

You can see detailed user manual here: 
[https://devopshq.github.io/FuzzyClassificator/](https://devopshq.github.io/FuzzyClassificator/)

**Please report all new bugs or the required functionality in new tasks in Open DevOps community.**

See article about math in FuzzyClassificator (russian):
[http://math-n-algo.blogspot.ru/2014/08/FuzzyClassificator.html](http://math-n-algo.blogspot.ru/2014/08/FuzzyClassificator.html)